### PR TITLE
Implement equality and hash operators and add a test

### DIFF
--- a/port_range/__init__.py
+++ b/port_range/__init__.py
@@ -119,6 +119,13 @@ class PortRange(object):
 
         return port_from, port_to
 
+    def __eq__(self, other):
+        """ Compare two port ranges. """
+        return self.bounds == other.bounds
+
+    def __hash__(self):
+        return self.__str__().__hash__()
+
     def __repr__(self):
         """ Print all components of the range. """
         return (

--- a/port_range/tests/test_port_range.py
+++ b/port_range/tests/test_port_range.py
@@ -81,6 +81,19 @@ class TestPortRange(unittest.TestCase):
         self.assertRaises(ValueError, PortRange, [42, 32, 3], True)
         self.assertRaises(ValueError, PortRange, [42, None, 32, 3, -4], True)
 
+    def test_equality_and_hash(self):
+        self.assertEqual(PortRange('80'), PortRange('80'))
+        self.assertEqual(PortRange('80-81'), PortRange('80-81'))
+        self.assertNotEqual(PortRange('80'), PortRange('80-81'))
+        self.assertEqual(PortRange('1027/15'), PortRange('1027/15'))
+        self.assertEqual(hash(PortRange('80')), hash(PortRange('80')))
+        self.assertEqual(hash(PortRange('80-81')), hash(PortRange('80-81')))
+        self.assertNotEqual(hash(PortRange('80')), hash(PortRange('80-81')))
+        self.assertEqual(
+            hash(PortRange('1027/15')),
+            hash(PortRange('1027/15'))
+        )
+
     def test_cidr_properties(self):
         port = PortRange('1027/15')
         self.assertEqual(port.base, 1027)


### PR DESCRIPTION
I found that two identical PortRange could not be compared for equality.  Equality tests were missing.